### PR TITLE
Fix typo in app.js

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,4 +1,4 @@
-'use struct';
+'use strict';
 
 /* global moment */
 


### PR DESCRIPTION
Fix typo of `use struct` to `use strict`
