### PR TITLE
Label start and end times

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -501,8 +501,8 @@ var timesched = angular
           lines.push('');
         lines.push(zone.timezoneName + '  [' + start.format('z; [UTC]ZZ') +
           (start.zone() != end.zone() ? '; timezone change' : '') + ']');
-        lines.push(start.format(fmt));
-        lines.push(end.format(fmt));
+        lines.push("Start: " + start.format(fmt));
+        lines.push("End: " + end.format(fmt));
       }
       return lines.join('\n');
     };


### PR DESCRIPTION
I used the "send using gmail" option to suggest a meeting time but the recipient thought both the start- and end times were options and chose to book the meeting in to start at the end time. This change might help avoid that issue in the future by clearly labelling which time is the start and which is the end.

For info, the text in the email was:

```
United Kingdom, London  [GMT/BST; UTC+0100]
14:30   Thu, Aug 14 2014
15:30   Thu, Aug 14 2014

Canada, Toronto  [EDT; UTC-0400]
09:30   Thu, Aug 14 2014
10:30   Thu, Aug 14 2014

View this time table online: http://bit.ly/1r76JbN
```

and the meeting ended up happening at 15:30 GMT/UTC.
